### PR TITLE
Fix Go version mismatch for Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: backend/go.sum
 
       - name: Download dependencies
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache-dependency-path: backend/go.sum
 
       - name: Build

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Update Go version from 1.23 to 1.25 to match go.mod requirement (1.25.5)
- Fixes Docker build failure in the publish workflow

## Test plan

- [ ] CI passes (backend tests and build)
- [ ] Docker publish workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)