### PR TITLE
Change frontend container to use non-privileged port 8080

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,12 +27,12 @@ services:
     container_name: songify-frontend
     restart: unless-stopped
     ports:
-      - "${PORT:-3000}:80"
+      - "${PORT:-3000}:8080"
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 30s
       timeout: 3s
       retries: 3

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,9 +31,9 @@ RUN chown -R nginx:nginx /usr/share/nginx/html \
 
 USER nginx
 
-EXPOSE 80
+EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:80/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Summary
- Changes the frontend nginx container to listen on port 8080 instead of port 80
- Port 80 requires root privileges to bind, while 8080 allows the container to run entirely as the non-root `nginx` user
- Improves container security posture

## Test plan
- [ ] Build the frontend container: `docker compose build frontend`
- [ ] Start the stack: `docker compose up -d`
- [ ] Verify the frontend is accessible on the configured external port (default 3000)
- [ ] Verify healthchecks pass: `docker compose ps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)