### PR TITLE
Fix rejoin to support multiple sessions with same admin credentials

### DIFF
--- a/backend/internal/handlers/sessions.go
+++ b/backend/internal/handlers/sessions.go
@@ -141,16 +141,19 @@ func (h *SessionHandler) Rejoin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.AdminName == "" || req.AdminPasswordHash == "" {
-		writeError(w, http.StatusBadRequest, "adminName and adminPasswordHash are required")
+	if req.FriendAccessKey == "" || req.AdminPasswordHash == "" {
+		writeError(w, http.StatusBadRequest, "friendAccessKey and adminPasswordHash are required")
 		return
 	}
 
-	session, err := h.queries.GetSessionByAdminCredentials(r.Context(), db.GetSessionByAdminCredentialsParams{
-		AdminName:         req.AdminName,
-		AdminPasswordHash: req.AdminPasswordHash,
-	})
+	session, err := h.queries.GetSessionByFriendKey(r.Context(), req.FriendAccessKey)
 	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+
+	// Verify the admin password
+	if session.AdminPasswordHash != req.AdminPasswordHash {
 		writeError(w, http.StatusUnauthorized, "invalid credentials")
 		return
 	}

--- a/backend/internal/models/models.go
+++ b/backend/internal/models/models.go
@@ -39,7 +39,7 @@ type JoinSessionResponse struct {
 }
 
 type RejoinSessionRequest struct {
-	AdminName         string `json:"adminName"`
+	FriendAccessKey   string `json:"friendAccessKey"`
 	AdminPasswordHash string `json:"adminPasswordHash"`
 }
 

--- a/frontend/src/pages/RejoinSessionPage.tsx
+++ b/frontend/src/pages/RejoinSessionPage.tsx
@@ -13,6 +13,7 @@ export function RejoinSessionPage() {
   const navigate = useNavigate()
   const setAdminAuth = useAuthStore((state) => state.setAdminAuth)
 
+  const [friendAccessKey, setFriendAccessKey] = useState('')
   const [adminName, setAdminName] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState('')
@@ -21,7 +22,7 @@ export function RejoinSessionPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (!adminName || !password) {
+    if (!friendAccessKey || !adminName || !password) {
       setError('Please fill in all fields')
       return
     }
@@ -31,7 +32,7 @@ export function RejoinSessionPage() {
 
     try {
       const passwordHash = await hashPassword(password, adminName)
-      const response = await api.rejoinSession(adminName, passwordHash)
+      const response = await api.rejoinSession(friendAccessKey, passwordHash)
 
       setAdminAuth(
         response.token,
@@ -41,7 +42,7 @@ export function RejoinSessionPage() {
       )
       navigate(`/session/${response.sessionId}`)
     } catch {
-      setError('Invalid credentials. Please check your name and password.')
+      setError('Invalid credentials. Please check your access key, name, and password.')
     } finally {
       setLoading(false)
     }
@@ -66,11 +67,24 @@ export function RejoinSessionPage() {
               Rejoin Session
             </CardTitle>
             <CardDescription>
-              Sign back into your existing session
+              Sign back into your existing session using your friend access key
             </CardDescription>
           </CardHeader>
           <CardContent>
             <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="friendAccessKey">Friend Access Key</Label>
+                <Input
+                  id="friendAccessKey"
+                  placeholder="e.g., happy-tiger-42"
+                  value={friendAccessKey}
+                  onChange={(e) => setFriendAccessKey(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  The key you shared with friends to join the session
+                </p>
+              </div>
+
               <div className="space-y-2">
                 <Label htmlFor="adminName">Your Name</Label>
                 <Input

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -73,10 +73,10 @@ export const api = {
     })
   },
 
-  rejoinSession: async (adminName: string, adminPasswordHash: string): Promise<RejoinSessionResponse> => {
+  rejoinSession: async (friendAccessKey: string, adminPasswordHash: string): Promise<RejoinSessionResponse> => {
     return request('/sessions/rejoin', {
       method: 'POST',
-      body: JSON.stringify({ adminName, adminPasswordHash }),
+      body: JSON.stringify({ friendAccessKey, adminPasswordHash }),
     })
   },
 


### PR DESCRIPTION
## Summary
- Fixes bug where admins couldn't rejoin sessions if they had multiple sessions with the same name/password
- Rejoin now uses the unique friend access key to identify the session

## Changes
- **Backend**: Update `RejoinSessionRequest` to use `friendAccessKey` instead of `adminName`
- **Backend**: Look up session by friend key, then verify password hash
- **Frontend**: Update rejoin form to ask for friend access key, admin name, and password

## Test plan
- [ ] Create two sessions with the same admin name and password
- [ ] Note the different friend access keys for each
- [ ] Rejoin using the friend access key for each session

🤖 Generated with [Claude Code](https://claude.com/claude-code)