### PR TITLE
Show song duration for approved/rejected requests

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -600,6 +600,9 @@ export function SessionPage() {
                         </p>
                       )}
                     </div>
+                    <span className="text-sm text-muted-foreground">
+                      {formatDuration(request.durationMs)}
+                    </span>
                     <StatusBadge status={request.status} />
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Display song duration in the request history section for approved/rejected songs
- Matches the display format used for pending requests

## Test plan
- [ ] Approve a song request and verify duration is visible in history
- [ ] Reject a song request and verify duration is visible in history

🤖 Generated with [Claude Code](https://claude.com/claude-code)