### PR TITLE
Fix frontend container port in docker-compose.prod.yml

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -30,12 +30,12 @@ services:
     container_name: songify-frontend
     restart: unless-stopped
     ports:
-      - "${PORT:-3000}:80"
+      - "${PORT:-3000}:8080"
     depends_on:
       backend:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/"]
       interval: 30s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
## Summary
- Fixed port mapping from `:80` to `:8080` for frontend container
- Fixed healthcheck URL to use port 8080 instead of 80
- Aligns docker-compose.prod.yml with nginx.conf which listens on port 8080

## Test plan
- [x] Verified no other port 80 artifacts remain in codebase
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)