### PR TITLE
Add configurable UID/GID for backend container user

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,9 +21,14 @@ FROM alpine:3.23
 
 WORKDIR /app
 
-# Install runtime dependencies and create non-root user
+# Build args for customizable UID/GID (useful for bind mount permissions)
+ARG UID=10001
+ARG GID=10001
+
+# Install runtime dependencies and create non-root user with known UID/GID
 RUN apk add --no-cache ca-certificates tzdata \
-    && adduser -D -g '' appuser
+    && addgroup -g ${GID} -S appgroup \
+    && adduser -u ${UID} -G appgroup -D -S appuser
 
 # Copy binary from builder
 COPY --from=builder /app/server .


### PR DESCRIPTION
## Summary
- Added `ARG UID=10001` and `ARG GID=10001` to backend Dockerfile
- Allows customizable file permissions when using bind mounts for data storage
- Default UID/GID of 10001 avoids conflicts with typical host users

## Usage
```bash
# Use defaults (UID/GID 10001)
docker build .

# Custom UID/GID to match host user
docker build --build-arg UID=1000 --build-arg GID=1000 .
```

## Test plan
- [ ] CI checks pass
- [ ] Docker build succeeds with default args
- [ ] Docker build succeeds with custom args

🤖 Generated with [Claude Code](https://claude.com/claude-code)