### PR TITLE
Fix chown group name in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,7 +34,7 @@ RUN apk add --no-cache ca-certificates tzdata \
 COPY --from=builder /app/server .
 
 # Create data directory for SQLite
-RUN mkdir -p /data && chown appuser:appuser /data
+RUN mkdir -p /data && chown appuser:appgroup /data
 
 # Switch to non-root user
 USER appuser


### PR DESCRIPTION
## Summary
- Fixed `chown appuser:appuser` to `chown appuser:appgroup`
- The group was renamed to `appgroup` in #25 but the chown command was missed

## Test plan
- [ ] CI checks pass
- [ ] Docker Build & Publish workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)