### PR TITLE
Add IPv6 listener to nginx config

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,5 +1,6 @@
 server {
     listen 8080;
+    listen [::]:8080;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
## Summary
- Added `listen [::]:8080;` to nginx.conf for IPv6 support
- Fixes healthcheck failures where wget prefers IPv6 (`::1`) but nginx only listened on IPv4

## Root cause
wget resolves `localhost` to `[::1]` (IPv6) first, but nginx was only bound to IPv4. curl worked because it falls back to IPv4.

## Test plan
- [ ] CI checks pass
- [ ] Docker healthcheck passes after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)