### PR TITLE
Add admin endpoint to archive all session song requests

### DIFF
--- a/backend/internal/database/queries/song_requests.sql
+++ b/backend/internal/database/queries/song_requests.sql
@@ -26,3 +26,6 @@ SELECT EXISTS(
 
 -- name: DeleteSongRequest :exec
 DELETE FROM song_requests WHERE id = ?;
+
+-- name: DeleteAllSongRequestsBySessionID :exec
+DELETE FROM song_requests WHERE session_id = ?;

--- a/backend/internal/db/querier.go
+++ b/backend/internal/db/querier.go
@@ -13,6 +13,7 @@ type Querier interface {
 	CreateProhibitedPattern(ctx context.Context, arg CreateProhibitedPatternParams) (ProhibitedPattern, error)
 	CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error)
 	CreateSongRequest(ctx context.Context, arg CreateSongRequestParams) (SongRequest, error)
+	DeleteAllSongRequestsBySessionID(ctx context.Context, sessionID string) error
 	DeleteProhibitedPattern(ctx context.Context, id int64) error
 	DeleteProhibitedPatternsBySessionID(ctx context.Context, sessionID string) error
 	DeleteSession(ctx context.Context, id string) error

--- a/backend/internal/db/song_requests.sql.go
+++ b/backend/internal/db/song_requests.sql.go
@@ -66,6 +66,15 @@ func (q *Queries) CreateSongRequest(ctx context.Context, arg CreateSongRequestPa
 	return i, err
 }
 
+const deleteAllSongRequestsBySessionID = `-- name: DeleteAllSongRequestsBySessionID :exec
+DELETE FROM song_requests WHERE session_id = ?
+`
+
+func (q *Queries) DeleteAllSongRequestsBySessionID(ctx context.Context, sessionID string) error {
+	_, err := q.db.ExecContext(ctx, deleteAllSongRequestsBySessionID, sessionID)
+	return err
+}
+
 const deleteSongRequest = `-- name: DeleteSongRequest :exec
 DELETE FROM song_requests WHERE id = ?
 `

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -89,6 +89,9 @@ func New(cfg *config.Config, queries *db.Queries) http.Handler {
 					r.Get("/", requestHandler.List)
 					r.Post("/", requestHandler.Submit)
 
+					// Admin-only: archive all requests
+					r.With(middleware.AdminOnlyMiddleware).Delete("/", requestHandler.ArchiveAll)
+
 					// Admin-only actions
 					r.Route("/{rid}", func(r chi.Router) {
 						r.Use(middleware.AdminOnlyMiddleware)


### PR DESCRIPTION
## Summary
- Adds DELETE `/api/sessions/{id}/requests` endpoint for admins to clear all song requests in a session
- Allows reusing the same session across multiple collaboration sessions without accumulated requests cluttering the interface

## Test plan
- [ ] Verify admin can call DELETE on `/api/sessions/{id}/requests` and all requests are removed
- [ ] Verify non-admin users receive 403 Forbidden
- [ ] Verify the endpoint is protected by auth middleware

🤖 Generated with [Claude Code](https://claude.com/claude-code)