### PR TITLE
Check Spotify connection before approving songs and add error toasts

### DIFF
--- a/frontend/src/components/ArchiveDialog.tsx
+++ b/frontend/src/components/ArchiveDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Loader2, AlertTriangle } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -34,8 +35,10 @@ export function ArchiveDialog({
       await api.archiveAllRequests(sessionId)
       onUpdate()
       onOpenChange(false)
+      toast.success('All requests archived')
     } catch {
       setError('Failed to archive requests')
+      toast.error('Failed to archive requests')
     } finally {
       setArchiving(false)
     }

--- a/frontend/src/components/PatternsDialog.tsx
+++ b/frontend/src/components/PatternsDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Loader2, X, Plus } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -46,8 +47,10 @@ export function PatternsDialog({
       await api.createProhibitedPattern(sessionId, patternType, pattern.trim())
       setPattern('')
       onUpdate()
+      toast.success('Pattern added')
     } catch {
       setError('Failed to add pattern')
+      toast.error('Failed to add pattern')
     } finally {
       setAdding(false)
     }
@@ -58,8 +61,10 @@ export function PatternsDialog({
     try {
       await api.deleteProhibitedPattern(sessionId, patternId)
       onUpdate()
+      toast.success('Pattern removed')
     } catch {
       setError('Failed to delete pattern')
+      toast.error('Failed to delete pattern')
     } finally {
       setDeletingId(null)
     }

--- a/frontend/src/components/TimeLimitDialog.tsx
+++ b/frontend/src/components/TimeLimitDialog.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
 import {
   Dialog,
   DialogContent,
@@ -60,8 +61,10 @@ export function TimeLimitDialog({
       await api.updateDurationLimit(sessionId, limitMs)
       onUpdate()
       onOpenChange(false)
+      toast.success('Time limit updated')
     } catch {
       setError('Failed to update time limit')
+      toast.error('Failed to update time limit')
     } finally {
       setSaving(false)
     }
@@ -74,8 +77,10 @@ export function TimeLimitDialog({
       await api.updateDurationLimit(sessionId, null)
       onUpdate()
       onOpenChange(false)
+      toast.success('Time limit cleared')
     } catch {
       setError('Failed to clear time limit')
+      toast.error('Failed to clear time limit')
     } finally {
       setSaving(false)
     }


### PR DESCRIPTION
## Summary
- Check Spotify authentication BEFORE marking songs as approved (fixes the silent failure bug)
- Add the track to Spotify playlist first, then mark as approved - if Spotify fails, the song isn't marked approved
- Show inline error message when admin needs to reconnect to Spotify
- Add toast notifications for success/error feedback across all API operations

## Changes
- **SessionPage**: Added toasts for submit, approve, reject, search, and Spotify auth operations
- **TimeLimitDialog**: Added toasts for save and clear operations  
- **PatternsDialog**: Added toasts for add and delete pattern operations
- **ArchiveDialog**: Added toasts for archive operation

## Test plan
- [ ] Rejoin a session as admin without Spotify connected
- [ ] Try to approve a song - should see error "Spotify connection required"
- [ ] Connect to Spotify and approve a song - should succeed with toast
- [ ] Test that failed API calls show error toasts
- [ ] Test that successful operations show success toasts

🤖 Generated with [Claude Code](https://claude.com/claude-code)