### PR TITLE
Fix Spotify session not restoring on page refresh

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -281,23 +281,24 @@ export function SessionPage() {
     }
   }, [sessionId, id, navigate])
 
-  // Try to restore Spotify session from stored token on mount (admin only)
-  useEffect(() => {
-    if (isAdmin) {
-      tryRestoreSpotifySession().then((restored) => {
-        if (restored) {
-          setSpotifyRestored(true) // Trigger re-render to update SpotifyStatus
-        }
-      })
-    }
-  }, [isAdmin])
-
   // Fetch session details
   const { data: session, isLoading: sessionLoading } = useQuery<Session>({
     queryKey: ['session', id],
     queryFn: () => api.getSession(id!),
     enabled: !!id,
   })
+
+  // Try to restore Spotify session from stored token (admin only)
+  // Runs after session loads so we can verify the linked playlist
+  useEffect(() => {
+    if (isAdmin && session?.spotifyPlaylistId) {
+      tryRestoreSpotifySession(session.spotifyPlaylistId).then((restored) => {
+        if (restored) {
+          setSpotifyRestored(true) // Trigger re-render to update SpotifyStatus
+        }
+      })
+    }
+  }, [isAdmin, session?.spotifyPlaylistId])
 
   // Fetch song requests with polling
   const { data: requests = [], isLoading: requestsLoading } = useQuery<SongRequest[]>({


### PR DESCRIPTION
## Summary
Fixes the issue where refreshing the page shows Spotify as disconnected even though a valid token exists in localStorage.

## Problem
- The Spotify SDK stores tokens in localStorage
- On page refresh, the `spotifyApi` module variable resets to `null`
- `isSpotifyAuthenticated()` returns `false` because it only checks the variable
- User sees amber "Reconnect" warning even though they're still authenticated

## Solution
Added functions to restore the session from localStorage:
- `hasStoredSpotifyToken()`: checks if there's a token in localStorage
- `tryRestoreSpotifySession()`: initializes SDK, authenticates using stored token, and **verifies with an actual API call** (`currentUser.profile`)
- SessionPage `useEffect`: automatically restores session for admins on mount

If the verification API call fails (expired token, revoked access, etc.), the token is cleared and the user sees the reconnect prompt.

## Test plan
- [ ] Connect Spotify to a session
- [ ] Verify green playlist indicator
- [ ] Refresh the page
- [ ] Verify green indicator persists (not amber warning)
- [ ] Approve a song to confirm session is functional
- [ ] Revoke app access in Spotify settings, refresh page
- [ ] Verify amber warning appears (token cleared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)