### PR TITLE
Fix playlist image not loading after Spotify session restore

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -76,11 +76,13 @@ function StatusBadge({ status }: { status: string }) {
 function SpotifyStatus({
   playlistId,
   playlistName,
+  isAuthenticated,
   onConnect,
   onChangePlaylist
 }: {
   playlistId: string | null | undefined
   playlistName: string | null | undefined
+  isAuthenticated: boolean
   onConnect: () => void
   onChangePlaylist: () => void
 }) {
@@ -98,7 +100,7 @@ function SpotifyStatus({
 
   // Fetch full playlist details from Spotify if authenticated (to get image)
   useEffect(() => {
-    if (!playlistId || !isSpotifyAuthenticated()) {
+    if (!playlistId || !isAuthenticated) {
       return
     }
 
@@ -131,7 +133,7 @@ function SpotifyStatus({
     return () => {
       controller.abort()
     }
-  }, [playlistId])
+  }, [playlistId, isAuthenticated])
 
   // Close dropdown when clicking outside
   useEffect(() => {
@@ -144,7 +146,7 @@ function SpotifyStatus({
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  const isConnected = isSpotifyAuthenticated()
+  const isConnected = isAuthenticated
 
   if (!playlistId) {
     return (
@@ -468,6 +470,7 @@ export function SessionPage() {
                   key={session?.spotifyPlaylistId || 'no-playlist'}
                   playlistId={session?.spotifyPlaylistId}
                   playlistName={session?.spotifyPlaylistName}
+                  isAuthenticated={isSpotifyAuthenticated()}
                   onConnect={handleSpotifyAuth}
                   onChangePlaylist={handleSpotifyAuth}
                 />


### PR DESCRIPTION
## Summary
Fixes the playlist album art not appearing after the Spotify session is restored on page refresh.

## Problem
The useEffect that fetches playlist details (including album art) only depended on `playlistId`:
1. Page loads → `isSpotifyAuthenticated()` is false → useEffect returns early
2. Session restores → component re-renders
3. useEffect doesn't re-run because `playlistId` hasn't changed
4. Album art stays blank

## Solution
- Added `isAuthenticated` prop to SpotifyStatus component
- Added it to the useEffect dependency array
- Now when auth state changes from false→true, the effect runs and fetches the playlist image

## Test plan
- [ ] Connect Spotify and link a playlist with album art
- [ ] Refresh the page
- [ ] Verify the playlist image loads after session restore

🤖 Generated with [Claude Code](https://claude.com/claude-code)