### PR TITLE
Move settings icon beside logout button

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -475,12 +475,6 @@ export function SessionPage() {
                   onChangePlaylist={handleSpotifyAuth}
                 />
               )}
-              {isAdmin && session && (
-                <AdminSettings
-                  session={session}
-                  onSessionUpdate={() => queryClient.invalidateQueries({ queryKey: ['session', id] })}
-                />
-              )}
               {isAdmin && friendAccessKey && (
                 <Button
                   variant="outline"
@@ -492,6 +486,12 @@ export function SessionPage() {
                   <span className="hidden sm:inline">{copiedKey ? 'Copied!' : friendAccessKey}</span>
                   <span className="sm:hidden">{copiedKey ? 'Copied!' : 'Share'}</span>
                 </Button>
+              )}
+              {isAdmin && session && (
+                <AdminSettings
+                  session={session}
+                  onSessionUpdate={() => queryClient.invalidateQueries({ queryKey: ['session', id] })}
+                />
               )}
               <Button variant="ghost" size="icon" onClick={handleLogout}>
                 <LogOut className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Reorders the admin header controls for a cleaner layout.

**Before:** SpotifyStatus → Settings → Share → Logout  
**After:** SpotifyStatus → Share → Settings → Logout

Groups the action buttons (settings, logout) together on the right.

## Test plan
- [ ] View admin session page
- [ ] Verify settings icon is now beside logout button

🤖 Generated with [Claude Code](https://claude.com/claude-code)