### PR TITLE
Add clear button to search field

### DIFF
--- a/frontend/src/pages/SessionPage.tsx
+++ b/frontend/src/pages/SessionPage.tsx
@@ -512,12 +512,27 @@ export function SessionPage() {
           </CardHeader>
           <CardContent>
             <div className="flex gap-2">
-              <Input
-                placeholder="Search for a song..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
-              />
+              <div className="relative flex-1">
+                <Input
+                  placeholder="Search for a song..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+                  className={searchQuery || searchResults.length > 0 ? 'pr-8' : ''}
+                />
+                {(searchQuery || searchResults.length > 0) && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSearchQuery('')
+                      setSearchResults([])
+                    }}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
               <Button onClick={handleSearch} disabled={isSearching}>
                 {isSearching ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Search'}
               </Button>


### PR DESCRIPTION
## Summary
Adds a small X button on the right side of the search input field that appears when there's text or search results.

Clicking it clears both the search query and the search results list.

## Test plan
- [ ] Type in the search field - X button appears
- [ ] Click X - field and results clear
- [ ] Search for something - X button appears
- [ ] Click X - query and results clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)