### PR TITLE
fix: clean up frontend code issues

### DIFF
--- a/frontend/src/components/AdminSettings.tsx
+++ b/frontend/src/components/AdminSettings.tsx
@@ -9,12 +9,14 @@
  * Each setting opens a dialog for detailed configuration.
  */
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useCallback } from 'react'
 import { Settings, Clock, Ban, Trash2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { TimeLimitDialog } from '@/components/TimeLimitDialog'
 import { PatternsDialog } from '@/components/PatternsDialog'
 import { ArchiveDialog } from '@/components/ArchiveDialog'
+import { useClickOutside } from '@/hooks/useClickOutside'
+import { formatDuration } from '@/lib/utils'
 import type { Session } from '@/types'
 
 interface AdminSettingsProps {
@@ -29,15 +31,7 @@ export function AdminSettings({ session, onSessionUpdate }: AdminSettingsProps) 
   const [archiveOpen, setArchiveOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setDropdownOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
+  useClickOutside(dropdownRef, useCallback(() => setDropdownOpen(false), []))
 
   return (
     <>
@@ -67,8 +61,7 @@ export function AdminSettings({ session, onSessionUpdate }: AdminSettingsProps) 
                 <span>Song Time Limit</span>
                 {session.songDurationLimitMs && (
                   <p className="text-xs text-muted-foreground">
-                    {Math.floor(session.songDurationLimitMs / 60000)}m{' '}
-                    {Math.floor((session.songDurationLimitMs % 60000) / 1000)}s
+                    {formatDuration(session.songDurationLimitMs)}
                   </p>
                 )}
               </div>

--- a/frontend/src/components/ArchiveDialog.tsx
+++ b/frontend/src/components/ArchiveDialog.tsx
@@ -33,10 +33,8 @@ export function ArchiveDialog({
   onUpdate,
 }: ArchiveDialogProps) {
   const [archiving, setArchiving] = useState(false)
-  const [error, setError] = useState('')
 
   const handleArchive = async () => {
-    setError('')
     setArchiving(true)
     try {
       await api.archiveAllRequests(sessionId)
@@ -44,7 +42,6 @@ export function ArchiveDialog({
       onOpenChange(false)
       toast.success('All requests archived')
     } catch {
-      setError('Failed to archive requests')
       toast.error('Failed to archive requests')
     } finally {
       setArchiving(false)
@@ -68,7 +65,6 @@ export function ArchiveDialog({
           <p className="text-sm text-muted-foreground">
             Use this to clear the queue when reusing a session for a new collaboration.
           </p>
-          {error && <p className="text-sm text-destructive mt-2">{error}</p>}
         </div>
 
         <DialogFooter>

--- a/frontend/src/components/PatternsDialog.tsx
+++ b/frontend/src/components/PatternsDialog.tsx
@@ -60,7 +60,6 @@ export function PatternsDialog({
       onUpdate()
       toast.success('Pattern added')
     } catch {
-      setError('Failed to add pattern')
       toast.error('Failed to add pattern')
     } finally {
       setAdding(false)
@@ -74,7 +73,6 @@ export function PatternsDialog({
       onUpdate()
       toast.success('Pattern removed')
     } catch {
-      setError('Failed to delete pattern')
       toast.error('Failed to delete pattern')
     } finally {
       setDeletingId(null)

--- a/frontend/src/components/TimeLimitDialog.tsx
+++ b/frontend/src/components/TimeLimitDialog.tsx
@@ -70,7 +70,6 @@ export function TimeLimitDialog({
       onOpenChange(false)
       toast.success('Time limit updated')
     } catch {
-      setError('Failed to update time limit')
       toast.error('Failed to update time limit')
     } finally {
       setSaving(false)
@@ -86,7 +85,6 @@ export function TimeLimitDialog({
       onOpenChange(false)
       toast.success('Time limit cleared')
     } catch {
-      setError('Failed to clear time limit')
       toast.error('Failed to clear time limit')
     } finally {
       setSaving(false)

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,20 @@
+import { useEffect, type RefObject } from 'react'
+
+/**
+ * Hook that triggers a callback when clicking outside of the referenced element.
+ * Useful for closing dropdowns, modals, etc.
+ */
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  onClickOutside: () => void
+) {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClickOutside()
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [ref, onClickOutside])
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/** Format milliseconds as M:SS (e.g., 3:45) */
+export function formatDuration(ms: number): string {
+  const minutes = Math.floor(ms / 60000)
+  const seconds = Math.floor((ms % 60000) / 1000)
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -188,11 +188,6 @@ export const api = {
 
   // ----- Prohibited Patterns -----
 
-  /** Get all prohibition patterns for a session */
-  getProhibitedPatterns: async (sessionId: string): Promise<ProhibitedPattern[]> => {
-    return request(`/sessions/${sessionId}/patterns`)
-  },
-
   /** Add a new prohibition pattern (blocks matching songs from search) */
   createProhibitedPattern: async (
     sessionId: string,

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -14,8 +14,6 @@ import { persist } from 'zustand/middleware'
 import type { AuthState } from '@/types'
 
 interface AuthStore extends AuthState {
-  /** Partial state update (for flexibility) */
-  setAuth: (auth: Partial<AuthState>) => void
   /** Set auth state after admin creates or rejoins a session */
   setAdminAuth: (token: string, sessionId: string, displayName: string, friendAccessKey: string) => void
   /** Set auth state after friend joins a session */
@@ -35,8 +33,6 @@ export const useAuthStore = create<AuthStore>()(
       isAdmin: false,
       displayName: null,
       friendAccessKey: null,
-
-      setAuth: (auth) => set((state) => ({ ...state, ...auth })),
 
       setAdminAuth: (token, sessionId, displayName, friendAccessKey) =>
         set({


### PR DESCRIPTION
## Summary
- Add `useClickOutside` hook to deduplicate click-outside dropdown logic (was in AdminSettings + SessionPage)
- Move `formatDuration` to shared utils, remove duplicate implementations
- Fix dual error notifications: use inline errors for validation, toast-only for API errors
- Remove unused state setter hack for Spotify restore (now uses query invalidation properly)
- Add `refetchIntervalInBackground: false` to stop polling when browser tab is hidden
- Remove dead code: unused `getProhibitedPatterns` API method and `setAuth` auth store method

## Test plan
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Frontend CI checks pass
- [ ] Verify dropdowns still close when clicking outside
- [ ] Verify error toasts appear for API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)